### PR TITLE
Add `get_extended_pubkey_display()` to HWI trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ pub trait HWI: Debug {
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// 3. Get the xpub with the given derivation path.
     async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
+    /// Get the xpub with the given derivation path, will ask user ACK for non "standard"
+    /// derivation path on some devices.
+    async fn get_extended_pubkey_display(&self, path: &DerivationPath) -> Result<Xpub, Error>;
     /// 4. Register a new wallet policy
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
     /// 5. Returns true if the wallet is registered

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -68,7 +68,7 @@ pub mod command {
                     {
                         if let Ok((device, _)) = device.wait_confirm().await {
                             let mut bb02 = BitBox02::from(device).with_network(network);
-                            if let Some(ref policy) = wallet.as_ref().map(|w| w.policy).flatten() {
+                            if let Some(policy) = wallet.as_ref().and_then(|w| w.policy) {
                                 bb02 = bb02.with_policy(policy)?;
                             }
                             hws.push(bb02.into());

--- a/src/bitbox.rs
+++ b/src/bitbox.rs
@@ -210,6 +210,28 @@ impl<T: Runtime + Sync + Send> HWI for BitBox02<T> {
         Ok(Xpub::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
     }
 
+    async fn get_extended_pubkey_display(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+        let fg = self
+            .client
+            .btc_xpub(
+                if self.network == bitcoin::Network::Bitcoin {
+                    pb::BtcCoin::Btc
+                } else {
+                    pb::BtcCoin::Tbtc
+                },
+                &Keypath::from(path),
+                if self.network == bitcoin::Network::Bitcoin {
+                    pb::btc_pub_request::XPubType::Xpub
+                } else {
+                    pb::btc_pub_request::XPubType::Tpub
+                },
+                true,
+            )
+            .await
+            .map_err(|e| HWIError::Device(e.to_string()))?;
+        Ok(Xpub::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
+    }
+
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {
         match script {
             AddressScript::P2TR(path) => {

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -97,6 +97,10 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
             .await?)
     }
 
+    async fn get_extended_pubkey_display(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+        Ok(self.client.get_extended_pubkey(path, true).await?)
+    }
+
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {
         match script {
             AddressScript::P2TR(path) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,11 @@ pub trait HWI: Debug {
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// Get the xpub with the given derivation path.
     async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
+    /// Get the xpub with the given derivation path, will ask user ACK for non "standard"
+    /// derivation path on some devices.
+    async fn get_extended_pubkey_display(&self, path: &DerivationPath) -> Result<Xpub, Error> {
+        self.get_extended_pubkey(path).await
+    }
     /// Register a new wallet policy.
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
     /// Returns true if the wallet is registered on the device.


### PR DESCRIPTION
This PR add a method to `HWI` trait for fetch an Xpub w/ a "non-standard" derivation path, this is  needed for Ledger & BitBox devices in order to fetch an Xpub w/ m/48'/0'/`1'`/2' for instance.

When this method is called the user will be prompt to ACK before generating the Xpub whereas calling `get_extended_pubkey()` will blindly generate the Xpub or fail if "non-standard" 