### PR TITLE
Update ledger_bitcoin_client to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "ledger_bitcoin_client"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bb192e14da7725505c49791fde863bafee2b28dede2f37e05559fe72c29416"
+checksum = "0bde374bb944a3cf65299c976cc7c06bd5bf1de9bcc543fba5b8463b554ca2fc"
 dependencies = [
  "async-trait",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bitbox-api = { version = "0.9.0", default-features = false, features = ["usb", "
 coldcard = { version = "0.12.2", optional = true }
 
 # ledger
-ledger_bitcoin_client = { version = "0.5.0", optional = true }
+ledger_bitcoin_client = { version = "0.6.0", optional = true }
 ledger-apdu = { version = "0.10", optional = true }
 ledger-transport-hidapi = { version = "0.10.0", optional = true }
 

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -9,6 +9,7 @@ use bitcoin::{
     psbt::Psbt,
 };
 use ledger_bitcoin_client::psbt::PartialSignature;
+use ledger_bitcoin_client::SignPsbtYieldedObject;
 
 use ledger_apdu::APDUAnswer;
 use ledger_transport_hidapi::TransportNativeHID;
@@ -172,19 +173,22 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
 
     async fn sign_tx(&self, psbt: &mut Psbt) -> Result<(), HWIError> {
         if let Some((policy, hmac)) = &self.options.wallet {
-            let sigs = self.client.sign_psbt(psbt, policy, hmac.as_ref()).await?;
-            for (i, sig) in sigs {
+            let yielded_objects = self.client.sign_psbt(psbt, policy, hmac.as_ref()).await?;
+            for (i, obj) in yielded_objects {
                 let input = psbt.inputs.get_mut(i).ok_or(HWIError::DeviceDidNotSign)?;
-                match sig {
-                    PartialSignature::Sig(key, sig) => {
-                        input.partial_sigs.insert(key, sig);
-                    }
-                    PartialSignature::TapScriptSig(key, Some(tapleaf_hash), sig) => {
-                        input.tap_script_sigs.insert((key, tapleaf_hash), sig);
-                    }
-                    PartialSignature::TapScriptSig(_, None, sig) => {
-                        input.tap_key_sig = Some(sig);
-                    }
+                match obj {
+                    SignPsbtYieldedObject::Partial(sig) => match sig {
+                        PartialSignature::Sig(key, sig) => {
+                            input.partial_sigs.insert(key, sig);
+                        }
+                        PartialSignature::TapScriptSig(key, Some(tapleaf_hash), sig) => {
+                            input.tap_script_sigs.insert((key, tapleaf_hash), sig);
+                        }
+                        PartialSignature::TapScriptSig(_, None, sig) => {
+                            input.tap_key_sig = Some(sig);
+                        }
+                    },
+                    _ => {} // Ignore MuSig2 and unknown payloads
                 }
             }
             Ok(())


### PR DESCRIPTION
This is only the first commit of #127, upgrading the ledger client but without yet adding MuSig2 support.

(compared to the commit in #127, here I renamed the variables `sigs` to `yielded_objects`)