### PR TITLE
service: poll unsupported devices

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -856,13 +856,23 @@ where
     Message: From<SigningDeviceMsg<Id>> + Send + Clone + 'static,
     Id: Send + Clone + 'static,
 {
-    // If device is already in the map, don't poll it again
-    if devices.lock().expect("poisoned").contains_key(id) {
-        tracing::trace!(
-            "should_poll({}): device already in map, returning false",
-            id
-        );
-        return false;
+    // If device is already in the map and supported, don't poll it again
+    match devices.lock().expect("poisoned").get(id) {
+        Some(SigningDevice::Supported(_)) => {
+            tracing::trace!(
+                "should_poll({}): supported device already in map, returning false",
+                id
+            );
+            return false;
+        }
+        Some(SigningDevice::Locked { .. }) => {
+            tracing::trace!(
+                "should_poll({}): locked device already in map, returning false",
+                id
+            );
+            return false;
+        }
+        _ => {}
     }
 
     let result = match handles.get(id) {


### PR DESCRIPTION
This PR solves (what appear to be) a weird (timing?) issue with Ledger devices:
In almosts cases when a ledger device change state (no_app_loaded/app_loaded), the path (`hid-api::DeviceInfo.path`) changes, and the original logic where relying on that for decide if we need to poll a device.
There is one case where the path seems not changing: when the service start with a device unlocked but app not loaded, the path will not change when we open/close the app.

We now not only rely on the id (generated from path + pid + vid) to decide if we need to poll a device, we always poll `Unsupported` devices even if they are already in `HwiService.devices`


  