### PR TITLE
refactor: expose per-device PSBT pruning requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,13 @@ pub enum DeviceKind {
     Jade,
 }
 
+impl DeviceKind {
+    /// See https://github.com/wizardsardine/liana/pull/750 for more details.
+    pub fn requires_psbt_pruning(&self) -> bool {
+        matches!(self, Self::BitBox02)
+    }
+}
+
 impl std::fmt::Display for DeviceKind {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
It would generalize PSBT pruning support in Liana: https://github.com/romanz/liana/commit/562cccfbebf58e6937d7f2e3bbe77673d229ef24.