### PR TITLE
hwi: add display toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ pub trait HWI: Debug {
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// 3. Get the xpub with the given derivation path.
     async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
+    /// Display xpubs on the device screen when the device supports it.
+    fn display(&self, _display: bool) {}
     /// 4. Register a new wallet policy
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
     /// 5. Returns true if the wallet is registered

--- a/src/bitbox.rs
+++ b/src/bitbox.rs
@@ -118,7 +118,7 @@ impl<T: Runtime> PairingBitbox02<T> {
 
 pub struct BitBox02<T: Runtime> {
     pub network: bitcoin::Network,
-    pub display_xpub: bool,
+    pub display_xpub: Mutex<bool>,
     pub client: PairedBitBox<T>,
     pub policy: Option<Policy>,
 }
@@ -132,7 +132,7 @@ impl<T: Runtime> std::fmt::Debug for BitBox02<T> {
 impl<T: Runtime> BitBox02<T> {
     pub fn from(paired_bitbox: PairedBitBox<T>) -> Self {
         BitBox02 {
-            display_xpub: false,
+            display_xpub: Mutex::new(false),
             network: bitcoin::Network::Bitcoin,
             client: paired_bitbox,
             policy: None,
@@ -144,8 +144,8 @@ impl<T: Runtime> BitBox02<T> {
         self
     }
 
-    pub fn display_xpub(mut self, value: bool) -> Self {
-        self.display_xpub = value;
+    pub fn display_xpub(self, value: bool) -> Self {
+        *self.display_xpub.lock().expect("poisoned") = value;
         self
     }
 
@@ -189,6 +189,7 @@ impl<T: Runtime + Sync + Send> HWI for BitBox02<T> {
     }
 
     async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+        let display = *self.display_xpub.lock().expect("poisoned");
         let fg = self
             .client
             .btc_xpub(
@@ -203,11 +204,15 @@ impl<T: Runtime + Sync + Send> HWI for BitBox02<T> {
                 } else {
                     pb::btc_pub_request::XPubType::Tpub
                 },
-                self.display_xpub,
+                display,
             )
             .await
             .map_err(|e| HWIError::Device(e.to_string()))?;
         Ok(Xpub::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
+    }
+
+    fn display(&self, display: bool) {
+        *self.display_xpub.lock().expect("poisoned") = display;
     }
 
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -38,7 +38,7 @@ pub use ledger_bitcoin_client::async_client::Transport;
 #[derive(Default)]
 struct CommandOptions {
     wallet: Option<(WalletPolicy, Option<[u8; 32]>)>,
-    display_xpub: bool,
+    display_xpub: std::sync::Mutex<bool>,
 }
 
 pub struct Ledger<T: Transport> {
@@ -48,8 +48,8 @@ pub struct Ledger<T: Transport> {
 }
 
 impl<T: Transport> Ledger<T> {
-    pub fn display_xpub(mut self, display: bool) -> Result<Self, HWIError> {
-        self.options.display_xpub = display;
+    pub fn display_xpub(self, display: bool) -> Result<Self, HWIError> {
+        *self.options.display_xpub.lock().expect("poisoned") = display;
         Ok(self)
     }
 
@@ -95,10 +95,12 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
     }
 
     async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
-        Ok(self
-            .client
-            .get_extended_pubkey(path, self.options.display_xpub)
-            .await?)
+        let display = *self.options.display_xpub.lock().expect("poisoned");
+        Ok(self.client.get_extended_pubkey(path, display).await?)
+    }
+
+    fn display(&self, display: bool) {
+        *self.options.display_xpub.lock().expect("poisoned") = display;
     }
 
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ pub trait HWI: Debug {
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// Get the xpub with the given derivation path.
     async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
+    /// Display xpubs on the device screen when the device supports it.
+    fn display(&self, _display: bool) {}
     /// Register a new wallet policy.
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
     /// Returns true if the wallet is registered on the device.

--- a/src/service.rs
+++ b/src/service.rs
@@ -117,7 +117,7 @@ where
         &self.kind
     }
 
-    pub fn get_extended_pubkey(&self, id: Id, path: &DerivationPath) {
+    pub fn get_extended_pubkey(&self, id: Id, path: &DerivationPath, display: bool) {
         let path = path.clone();
         let sender = self.sender.clone();
         let fg = self.fingerprint;
@@ -128,6 +128,7 @@ where
             path
         );
         self.rt.spawn(async move {
+            device.display(display);
             match (*device).get_extended_pubkey(&path).await {
                 Ok(xpub) => {
                     tracing::debug!(
@@ -1694,7 +1695,7 @@ fn handle_coldcard<Message, Id>(
                                         "handle_coldcard[{}]: version supported, creating Supported device",
                                         id_clone
                                     );
-                                    SigningDevice::Supported (SupportedDevice{
+                                    SigningDevice::Supported(SupportedDevice {
                                         id: id_clone.clone(),
                                         device,
                                         kind: DeviceKind::Coldcard,


### PR DESCRIPTION
This PR add a `display()` method, mainly useful with ledger devices to notify the device uncommon path on xpub fetch must prompt user for ACK.